### PR TITLE
Fix a sql query and fix admin quality checks downloads

### DIFF
--- a/src/Website/Data/Repositories/VersionsRepository.cs
+++ b/src/Website/Data/Repositories/VersionsRepository.cs
@@ -54,7 +54,7 @@ namespace Website.Data.Repositories
 
         public async Task<MVersion> GetVersionAsync(int versionId, bool isSeller)
         {
-            string sql = "SELECT v.*, b.Id, b.Name, p.Id, p.Name, p.Price, p.IsEnabled FROM dbo.Versions v JOIN dbo.Branches b ON v.BranchId = b.Id " +
+            string sql = "SELECT v.*, b.Id, b.Name, p.Id, p.Name, p.Price, p.IsEnabled, p.IsLoaderEnabled FROM dbo.Versions v JOIN dbo.Branches b ON v.BranchId = b.Id " +
                 "JOIN dbo.Products p ON p.Id = b.ProductId WHERE v.Id = @versionId ";
 
             if (!isSeller)

--- a/src/Website/Server/Controllers/VersionsController.cs
+++ b/src/Website/Server/Controllers/VersionsController.cs
@@ -75,7 +75,7 @@ namespace Website.Server.Controllers
             }
 
             var version = await versionsRepository.GetVersionAsync(versionId, isOwner);
-            if (!isOwner || !User.IsInRole(RoleConstants.AdminRoleId))
+            if (!isOwner && !User.IsInRole(RoleConstants.AdminRoleId))
             {
                 if (version.Branch.Product.IsLoaderEnabled)
                 {


### PR DESCRIPTION
The IsLoaderEnabled property is used in the DownloadVersionAsync method.
Currently the page returns an error when you try to download a plugin, this line fixes it.
The line that uses the IsLoaderEnabled property: https://github.com/RestoreMonarchy/UnturnedStore/blob/586110e2c46d5d9a4df2c55f23a0c4017820c1fc/src/Website/Server/Controllers/VersionsController.cs#L80